### PR TITLE
show webprefix in link text on community page

### DIFF
--- a/source/community/index.html
+++ b/source/community/index.html
@@ -8,7 +8,7 @@ redirect_from:
 ---
 
           <section id="intro" class="intro wrapper">
-            <div>The International Image Interoperability Framework (IIIF) encompasses a large and growing community of interested individuals and organizations and a <a href="{{ site.url }}{{ site.baseurl }}/community/consortium/">Consortium</a> (IIIF Consortium or IIIF-C) of institutions dedicated to leading and sustaining the IIIF. As a community-driven initiative, IIIF thrives on active discussion, input, and feedback from a wide array of diverse individuals from libraries, museums, cultural heritage institutions, software firms, and other organizations working with digital images and audio/visual materials. We welcome any organization or individual interested in adopting the IIIF, developing software to support it, or giving feedback on the effort to get involved. All participants in all IIIF activities are expected to follow the <a href="{{ site.url }}{{ site.baseurl }}/event/conduct">IIIF code of conduct</a>.</div>
+            <div>The International Image Interoperability Framework (IIIF) encompasses a large and growing community of interested individuals and organizations and a <a href="/community/consortium/">Consortium</a> (IIIF Consortium or IIIF-C) of institutions dedicated to leading and sustaining the IIIF. As a community-driven initiative, IIIF thrives on active discussion, input, and feedback from a wide array of diverse individuals from libraries, museums, cultural heritage institutions, software firms, and other organizations working with digital images and audio/visual materials. We welcome any organization or individual interested in adopting the IIIF, developing software to support it, or giving feedback on the effort to get involved. All participants in all IIIF activities are expected to follow the <a href="/event/conduct">IIIF code of conduct</a>.</div>
           </section>
 
           <section id="how-to-get-involved" class="get-involved wrapper">
@@ -27,13 +27,13 @@ redirect_from:
                 <pre style="padding-left: 30px"><a href="http://bit.ly/iiif-slack">http://bit.ly/iiif-slack</a></pre></div>
 
             <div>Attend a IIIF Event:
-                <pre style="padding-left: 30px"><a href="{{ site.url }}{{ site.baseurl }}/event/">{{ site.url }}{{ site.baseurl }}/event/</a></pre></div>
+                <pre style="padding-left: 30px"><a href="/event/">{{ page.webprefix }}/event/</a></pre></div>
 
             <div>Submit a news items to the IIIF Community Newsletter:
                 <pre style="padding-left: 30px"><a href="https://goo.gl/forms/2LMe9zUHVBEbI62C3">IIIF Newsletter submission form</a></pre></div>
 
             <div>Participate in bi-weekly teleconferences:
-                <pre style="padding-left: 30px"><a href="{{ site.url }}{{ site.baseurl }}/community/call">{{ site.url }}{{ site.baseurl }}/community/call</a></pre></div>
+                <pre style="padding-left: 30px"><a href="/community/call">{{ page.webprefix }}/community/call</a></pre></div>
 
             <div><p>The schedule for all IIIF calls and meetings can be found on the <a href="groups/">IIIF Community Calendar</a>. All IIIF call notes and working documents can be accessed in the <a href="https://drive.google.com/drive/folders/0B9EeoRu2zWeraXpHNXpnZThUZVE?usp=sharing">IIIF Google Drive directory</a>.</p></div>
           </section>
@@ -42,7 +42,7 @@ redirect_from:
             <h2>Community groups & committees</h2>
             <div>There are a number of <a href="groups/">community and technical groups</a>, open to participation from all interested parties, that focus on different areas of interest related to IIIF.</div>
             <br/>
-            <div>There are also a number of standing committees made up of community and consortium members with various rules on memebrship. These include the <a href="{{ site.url }}{{ site.baseurl }}/community/trc/">Technical Review Committee</a>, <a href="{{ page.webprefix }}/api/annex/notes/editors/#editorial-team-membership-and-selection">Editorial Committee</a> and <a href="{{ site.url }}{{ site.baseurl }}/community/consortium/mou/exhibit_b/#coordinating-committee">the Coordinating Committee</a>.</div>
+            <div>There are also a number of standing committees made up of community and consortium members with various rules on memebrship. These include the <a href="/community/trc/">Technical Review Committee</a>, <a href="/api/annex/notes/editors/#editorial-team-membership-and-selection">Editorial Committee</a> and <a href="/community/consortium/mou/exhibit_b/#coordinating-committee">the Coordinating Committee</a>.</div>
           </section>
 
           <section class="participants wrapper">

--- a/source/community/index.html
+++ b/source/community/index.html
@@ -8,7 +8,7 @@ redirect_from:
 ---
 
           <section id="intro" class="intro wrapper">
-            <div>The International Image Interoperability Framework (IIIF) encompasses a large and growing community of interested individuals and organizations and a <a href="/community/consortium/">Consortium</a> (IIIF Consortium or IIIF-C) of institutions dedicated to leading and sustaining the IIIF. As a community-driven initiative, IIIF thrives on active discussion, input, and feedback from a wide array of diverse individuals from libraries, museums, cultural heritage institutions, software firms, and other organizations working with digital images and audio/visual materials. We welcome any organization or individual interested in adopting the IIIF, developing software to support it, or giving feedback on the effort to get involved. All participants in all IIIF activities are expected to follow the <a href="/event/conduct">IIIF code of conduct</a>.</div>
+            <div>The International Image Interoperability Framework (IIIF) encompasses a large and growing community of interested individuals and organizations and a <a href="{{ site.url }}{{ site.baseurl }}/community/consortium/">Consortium</a> (IIIF Consortium or IIIF-C) of institutions dedicated to leading and sustaining the IIIF. As a community-driven initiative, IIIF thrives on active discussion, input, and feedback from a wide array of diverse individuals from libraries, museums, cultural heritage institutions, software firms, and other organizations working with digital images and audio/visual materials. We welcome any organization or individual interested in adopting the IIIF, developing software to support it, or giving feedback on the effort to get involved. All participants in all IIIF activities are expected to follow the <a href="{{ site.url }}{{ site.baseurl }}/event/conduct">IIIF code of conduct</a>.</div>
           </section>
 
           <section id="how-to-get-involved" class="get-involved wrapper">
@@ -27,27 +27,27 @@ redirect_from:
                 <pre style="padding-left: 30px"><a href="http://bit.ly/iiif-slack">http://bit.ly/iiif-slack</a></pre></div>
 
             <div>Attend a IIIF Event:
-                <pre style="padding-left: 30px"><a href="/event/">{{ page.webprefix }}/event/</a></pre></div>
+                <pre style="padding-left: 30px"><a href="{{ site.url }}{{ site.baseurl }}/event/">{{ page.webprefix }}/event/</a></pre></div>
 
             <div>Submit a news items to the IIIF Community Newsletter:
                 <pre style="padding-left: 30px"><a href="https://goo.gl/forms/2LMe9zUHVBEbI62C3">IIIF Newsletter submission form</a></pre></div>
 
             <div>Participate in bi-weekly teleconferences:
-                <pre style="padding-left: 30px"><a href="/community/call">{{ page.webprefix }}/community/call</a></pre></div>
+                <pre style="padding-left: 30px"><a href="{{ site.url }}{{ site.baseurl }}/community/call">{{ page.webprefix }}/community/call</a></pre></div>
 
-            <div><p>The schedule for all IIIF calls and meetings can be found on the <a href="groups/">IIIF Community Calendar</a>. All IIIF call notes and working documents can be accessed in the <a href="https://drive.google.com/drive/folders/0B9EeoRu2zWeraXpHNXpnZThUZVE?usp=sharing">IIIF Google Drive directory</a>.</p></div>
+            <div><p>The schedule for all IIIF calls and meetings can be found on the <a href="{{ site.url }}{{ site.baseurl }}/community/groups/">IIIF Community Calendar</a>. All IIIF call notes and working documents can be accessed in the <a href="https://drive.google.com/drive/folders/0B9EeoRu2zWeraXpHNXpnZThUZVE?usp=sharing">IIIF Google Drive directory</a>.</p></div>
           </section>
 
           <section id="community-groups" class="quick-start wrapper">
             <h2>Community groups & committees</h2>
-            <div>There are a number of <a href="groups/">community and technical groups</a>, open to participation from all interested parties, that focus on different areas of interest related to IIIF.</div>
+            <div>There are a number of <a href="{{ site.url }}{{ site.baseurl }}/community/groups/">community and technical groups</a>, open to participation from all interested parties, that focus on different areas of interest related to IIIF.</div>
             <br/>
-            <div>There are also a number of standing committees made up of community and consortium members with various rules on memebrship. These include the <a href="/community/trc/">Technical Review Committee</a>, <a href="/api/annex/notes/editors/#editorial-team-membership-and-selection">Editorial Committee</a> and <a href="/community/consortium/mou/exhibit_b/#coordinating-committee">the Coordinating Committee</a>.</div>
+            <div>There are also a number of standing committees made up of community and consortium members with various rules on memebrship. These include the <a href="{{ site.url }}{{ site.baseurl }}/community/trc/">Technical Review Committee</a>, <a href="{{ page.webprefix }}/api/annex/notes/editors/#editorial-team-membership-and-selection">Editorial Committee</a> and <a href="{{ site.url }}{{ site.baseurl }}/community/consortium/mou/exhibit_b/#coordinating-committee">the Coordinating Committee</a>.</div>
           </section>
 
           <section class="participants wrapper">
             <h2>Participating Institutions</h2>
-            <p>The IIIF community consists of a rapidly growing number of cultural heritage institutions and open source software companies and projects committed to sharing and displaying image resources across repositories and the web. Participating institutions include, with members of the <a href="consortium/">IIIF Consortium</a> marked in bold:</p>
+            <p>The IIIF community consists of a rapidly growing number of cultural heritage institutions and open source software companies and projects committed to sharing and displaying image resources across repositories and the web. Participating institutions include, with members of the <a href="{{ site.url }}{{ site.baseurl }}/community/consortium/">IIIF Consortium</a> marked in bold:</p>
             <ul>
             {% for i in site.data.institutions %}
               <li>


### PR DESCRIPTION
Anchor text was, e.g., just "/event/" rather than "https://iiif.io/event/""



<img width="464" alt="screen shot 2018-12-04 at 9 36 46 am" src="https://user-images.githubusercontent.com/999701/49432681-2610c600-f7a8-11e8-81f6-f10e9727e1ee.png">