### PR TITLE
Update RAIS name and description

### DIFF
--- a/source/_data/image_servers.yml
+++ b/source/_data/image_servers.yml
@@ -30,21 +30,21 @@
   - >
     Loris is an open source, Python-based image server that supports the IIIF
     Image API ver 2.0. Loris supports JPEG and TIFF sources as well as JPEG2000.
-- name: Ruby Advanced Image Server (RAIS)
-  uri: https://github.com/uoregon-libraries/rais-image-server/wiki
+- name: Rodent-Assimilated Image Server (RAIS)
+  uri: https://github.com/uoregon-libraries/rais-image-server
   blurb:
   - >
-    RAIS is a high-performance IIIF Image server written in Go. It supports level 2 
-    of IIIF Image 2.1 as well as some optional features like max image size. It has 
-    direct integration with openjpeg, making its JP2 decoding extremely fast. It 
-    also has ImageMagick bindings for fast decoding of non-JP2 sources. It can 
-    optionally cache tiles to memory using a very intelligent cache (2Q LRU). 
+    RAIS is a high-performance IIIF Image server written in Go aimed primarily
+    at handling JP2 images.  It has direct integration with openjpeg, making
+    its JP2 decoding extremely fast. It has an optional plugin which can be
+    used to add ImageMagick bindings for fast decoding of non-JP2 sources. It
+    can optionally cache tiles to memory using an intelligent 2Q LRU cache.
   - >
     Plugins are supported to allow operations like pulling from S3 on demand and 
     adding arbitrary middleware.
   - >
-    RAIS is IIIF compatible ( 
-    Project [GitHub repo](https://github.com/uoregon-libraries/rais-image-server)  -  [Wiki](https://github.com/uoregon-libraries/rais-image-server/wiki) ).
+    RAIS supports level 2 of the IIIF Image API 2.1 as well as some optional features like max image size.
+    (Project [GitHub repo](https://github.com/uoregon-libraries/rais-image-server)  -  [Wiki](https://github.com/uoregon-libraries/rais-image-server/wiki)).
 - name: ContentDM
   uri: http://www.contentdm.org/
   blurb:


### PR DESCRIPTION
- Fixes the name to reflect the official project's name
- Updates the copy to more effectively express what RAIS is
- Fixes the main link to point to the github page, not the wiki